### PR TITLE
git for arm open-iot-sdk path is changed for compilation issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -277,12 +277,12 @@
 	platforms = genio
 [submodule "open-iot-sdk"]
 	path = third_party/open-iot-sdk/sdk
-	url = https://git.gitlab.arm.com/iot/open-iot-sdk/sdk.git
+	url = https://gitlab.arm.com/iot/open-iot-sdk/sdk.git
 	branch = main
 	platforms = openiotsdk
 [submodule "open-iot-sdk-storage"]
 	path = third_party/open-iot-sdk/storage
-	url = https://git.gitlab.arm.com/iot/open-iot-sdk/storage.git
+	url = https://gitlab.arm.com/iot/open-iot-sdk/libraries/storage.git
 	branch = main
 	platforms = openiotsdk
 [submodule "bouffalolab_sdk"]


### PR DESCRIPTION
Changes

- Updated open-iot-sdk submodule URL:
- Removed incorrect git. subdomain
- Updated open-iot-sdk-storage submodule URL:
- Fixed domain (git.gitlab.arm.com → gitlab.arm.com)
- Updated repository path to libraries/storage.git

Impact

- Ensures submodules can be cloned and initialized correctly
- Resolves build/compilation issues related to missing dependencies